### PR TITLE
Viewer fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,9 @@ module.exports = function(grunt) {
       options: {
         explicitArray: false,
         ignoreAttrs: true,
+
+	// option for xml2js within grunt-convert
+	tagNameProcessors: [function(str) {return str.replace(/^sdk:/, '');}]
       },
       sdk: {
         src: ['<%= curl.sdk.dest %>'],
@@ -73,21 +76,6 @@ module.exports = function(grunt) {
       sysimg: {
         src: ['<%= curl.sysimg.dest %>'],
         dest: 'src/data/sysimg.json'
-      }
-    },
-
-    frep: {
-      repository: {
-        options: {
-          replacements: {
-            'sdk:': ''
-          }
-        },
-        files: {
-          '<%= convert.sdk.dest %>': ['<%= convert.sdk.dest %>'],
-          '<%= convert.addon.dest %>': ['<%= convert.addon.dest %>'],
-          '<%= convert.sysimg.dest %>': ['<%= convert.sysimg.dest %>']
-        }
       }
     },
 
@@ -213,7 +201,7 @@ module.exports = function(grunt) {
 
   // Default task to be run.
   grunt.registerTask('update', ['curl']);
-  grunt.registerTask('data', ['update', 'convert', 'frep']);
+  grunt.registerTask('data', ['update', 'convert']);
   grunt.registerTask('default', ['jshint', 'clean', 'assemble', 'copy']);
   grunt.registerTask('debug', ['clean', 'assemble']);
 };

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-convert": "~0.1.8",
+    "grunt-convert": "~0.1.9",
     "grunt-curl": "~1.4.0",
-    "grunt-frep": "~0.1.2",
     "handlebars-helper-prettify": "~0.2.1",
     "matchdep": "~0.3.0"
   },

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -63,6 +63,15 @@ var helpers = {
     return path.basename(file);
   },
 
+  forceArray: function (obj, prop) {
+    if (Object.prototype.toString.call(obj[prop]) === '[object Array]') {
+      return;
+    } else {
+      obj[prop] = [obj[prop]];
+      return;
+    }
+  },
+
 };
 
 // Export helpers

--- a/src/templates/pages/doc.hbs
+++ b/src/templates/pages/doc.hbs
@@ -8,17 +8,20 @@ area: SDK
 <h1>{{title}}</h1>
 {{{md './src/content/doc.md'}}}
 {{#if repository.sdk-repository.doc}}
-  <h2>Documentation</h2>
-  <dl class="dl-horizontal">
-    <dt>revision</dt>
-    <dd>{{ repository.sdk-repository.doc.revision }}</dd>
-    <dt>api-level</dt>
-    <dd>{{ repository.sdk-repository.doc.api-level }}</dd>
-    <dt>size</dt>
-    <dd>{{toAbbr repository.sdk-repository.doc.archives.archive.size }}b</dd>
-    <dt>checksum</dt>
-    <dd>{{ repository.sdk-repository.doc.archives.archive.checksum }}</dd>
-    <dt>url</dt>
-    <dd class="separator"><a class="btn btn-primary" href="http://dl-ssl.google.com/android/repository/{{ repository.sdk-repository.doc.archives.archive.url }}">{{ repository.sdk-repository.doc.archives.archive.url }}</a></dd>
-  </dl>
+{{{forceArray repository.sdk-repository "doc"}}}
+  {{#withSort repository.sdk-repository.doc "revision" dir="desc"}}
+    <h2>Documentation</h2>
+    <dl class="dl-horizontal">
+      <dt>revision</dt>
+      <dd>{{ revision }}</dd>
+      <dt>api-level</dt>
+      <dd>{{ api-level }}</dd>
+      <dt>size</dt>
+      <dd>{{toAbbr archives.archive.size }}b</dd>
+      <dt>checksum</dt>
+      <dd>{{ archives.archive.checksum }}</dd>
+      <dt>url</dt>
+      <dd class="separator"><a class="btn btn-primary" href="http://dl-ssl.google.com/android/repository/{{ archives.archive.url }}">{{ archives.archive.url }}</a></dd>
+    </dl>
+    {{/withSort}}
   {{/if }}

--- a/src/templates/pages/platform-tool.hbs
+++ b/src/templates/pages/platform-tool.hbs
@@ -8,19 +8,22 @@ area: SDK
 <h1>{{title}}</h1>
 {{{md './src/content/platform-tool.md'}}}
 {{#if repository.sdk-repository.platform-tool}}
-  <h2>platform-tool</h2>
-  <dl class="dl-horizontal">
-    <dt>revision</dt>
-    <dd>{{ repository.sdk-repository.platform-tool.revision.major }}</dd>
-    <dd>{{ repository.sdk-repository.platform-tool.revision.minor }}</dd>
-    <dd>{{ repository.sdk-repository.platform-tool.revision.micro }}</dd>
-    {{#each repository.sdk-repository.platform-tool.archives.archive}}
-    <dt>size</dt>
-    <dd>{{toAbbr size }}b</dd>
-    <dt>checksum</dt>
-    <dd>{{ checksum }}</dd>
-    <dt>url</dt>
-    <dd class="separator"><a class="btn btn-primary" href="http://dl-ssl.google.com/android/repository/{{ url }}">{{ url }}</a></dd>
-    {{/each}}
-  </dl>
+{{{forceArray repository.sdk-repository "platform-tool"}}}
+  {{#withSort repository.sdk-repository.platform-tool "revision.major" dir="desc"}}
+    <h2>platform-tool {{revision.major}}.{{revision.minor}}.{{revision.micro}}</h2>
+    <dl class="dl-horizontal">
+      <dt>revision</dt>
+      <dd>{{ revision.major }}</dd>
+      <dd>{{ revision.minor }}</dd>
+      <dd>{{ revision.micro }}</dd>
+      {{#each archives.archive}}
+      <dt>size</dt>
+      <dd>{{toAbbr size }}b</dd>
+      <dt>checksum</dt>
+      <dd>{{ checksum }}</dd>
+      <dt>url</dt>
+      <dd class="separator"><a class="btn btn-primary" href="http://dl-ssl.google.com/android/repository/{{ url }}">{{ url }}</a></dd>
+      {{/each}}
+    </dl>
+    {{/withSort }}
   {{/if}}

--- a/src/templates/partials/navbar.hbs
+++ b/src/templates/partials/navbar.hbs
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/index.html">Viewer</a>
+      <a class="navbar-brand" href="/viewer/index.html">Viewer</a>
     </div>
 
     <div class="navbar-collapse collapse">


### PR DESCRIPTION
If you look at http://ady.my/viewer/platform-tool/ and http://ady.my/viewer/doc/, you will notice that currently (as of 1e8988a7beec45af0afd1b7b50114cf10f6b18bf) there are no buttons for downloading the platform-tools or the docs.  This is because the sdk repository for which the pages were created included a "platform preview" for Android M, and so there were multiple versions of platform-tools and docs included in the repository.  The Viewer was not able to handle multiple versions.

This pull request fixes the Viewer so that it handles multiple versions for platform-tools and docs.  It also has a couple commits fixing/changing some other minor things.